### PR TITLE
Fix for list shim

### DIFF
--- a/setup_test.go
+++ b/setup_test.go
@@ -26,8 +26,8 @@ func runTestCase(t *testing.T, tc testCase) {
 	for name, converter := range converters {
 		t.Run(name, func(tt *testing.T) {
 			result, err := converter.Convert(tc.body, textplain.DefaultLineLength)
-			assert.Nil(t, err)
-			assert.Equal(t, tc.expect, result)
+			assert.Nil(tt, err)
+			assert.Equal(tt, tc.expect, result)
 		})
 	}
 

--- a/textplain_test.go
+++ b/textplain_test.go
@@ -152,6 +152,11 @@ func TestLists(t *testing.T) {
 			body:   "<p>hello</p>\n\n\n<ul><li>item 1</li><li>item 2</li><li>item 3</li></ul>",
 			expect: "hello\n\n* item 1\n* item 2\n* item 3",
 		},
+		{
+			name:   "list with leading and trailing whitespace",
+			body:   "<p>hello</p>\n\n\n<ul><li>item 1</li><li>item 2</li><li>item 3</li></ul>\n\n<p>hi</p>",
+			expect: "hello\n\n* item 1\n* item 2\n* item 3\n\nhi",
+		},
 	})
 }
 

--- a/textplain_test.go
+++ b/textplain_test.go
@@ -147,6 +147,11 @@ func TestLists(t *testing.T) {
 			body:   "<ul><li>item 1</li>  \t\n\t <li>item 2</li><li>item 3</li></ul>",
 			expect: "* item 1\n* item 2\n* item 3",
 		},
+		{
+			name:   "list with leading whitespace",
+			body:   "<p>hello</p>\n\n\n<ul><li>item 1</li><li>item 2</li><li>item 3</li></ul>",
+			expect: "hello\n\n* item 1\n* item 2\n* item 3",
+		},
 	})
 }
 

--- a/tree.go
+++ b/tree.go
@@ -291,10 +291,13 @@ func (t *TreeConverter) fixSpacing(text string) string {
 	processed = append(processed, text[:2]...)
 	idx := 1
 
+	var inList = (processed[0] == '*' && processed[1] == ' ')
+
 	for i := 2; i < len(text); i++ {
 
 		switch processed[idx] {
 		case '\n':
+
 			if text[i] == '\t' || text[i] == ' ' {
 				continue
 			}
@@ -303,10 +306,14 @@ func (t *TreeConverter) fixSpacing(text string) string {
 				continue
 			}
 
-			// shim to clear whitespace between li tags
-			if processed[idx-1] == '\n' && len(text) > i && (text[i] == '*' && text[i+1] == ' ') {
-				processed[idx] = '*'
+			if inList && text[i] == '\n' {
 				continue
+			}
+
+			if text[i] == '*' && text[i+1] == ' ' {
+				inList = true
+			} else {
+				inList = false
 			}
 
 		case ' ':

--- a/tree.go
+++ b/tree.go
@@ -293,6 +293,7 @@ func (t *TreeConverter) fixSpacing(text string) string {
 
 	var inList = (processed[0] == '*' && processed[1] == ' ')
 
+tidyLoop:
 	for i := 2; i < len(text); i++ {
 
 		switch processed[idx] {
@@ -307,7 +308,15 @@ func (t *TreeConverter) fixSpacing(text string) string {
 			}
 
 			if inList && text[i] == '\n' {
-				continue
+				// lookahead through any whitespace to make sure we are still in a list
+				for j := i; j < len(text); j++ {
+					if text[j] == '\t' || text[j] == ' ' || text[j] == '\n' {
+						continue
+					}
+					if text[j] == '*' && j+1 < len(text) && text[j+1] == ' ' {
+						continue tidyLoop
+					}
+				}
 			}
 
 			if text[i] == '*' && text[i+1] == ' ' {


### PR DESCRIPTION
List shim was accidentally trimming spacing around lists. This accounts better for the state when shimming lists.