### PR TITLE
Support for non-alt images with links

### DIFF
--- a/textplain_test.go
+++ b/textplain_test.go
@@ -398,6 +398,11 @@ func TestLinks(t *testing.T) {
 			expect: `Hello 
 ( gopher://example.com/` + strings.Repeat("A", textplain.DefaultLineLength) + ` )`,
 		},
+		{
+			name:   "link wrapping image",
+			body:   `<a href="http://example.com"><img src="https://images.com/image.png" /></a>`,
+			expect: `( http://example.com )`,
+		},
 	})
 
 }

--- a/tree.go
+++ b/tree.go
@@ -171,6 +171,9 @@ func (t *TreeConverter) doConvert(n *html.Node) ([]string, error) {
 					parts = append(parts, href)
 					continue
 				} else if text == "" {
+					if containsImg(c) {
+						parts = append(parts, "( "+href+" )")
+					}
 					continue
 				}
 
@@ -187,6 +190,18 @@ func (t *TreeConverter) doConvert(n *html.Node) ([]string, error) {
 	}
 
 	return parts, nil
+}
+
+func containsImg(n *html.Node) bool {
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if c.DataAtom == atom.Img || c.DataAtom == atom.Image {
+			return true
+		}
+		if containsImg(c) {
+			return true
+		}
+	}
+	return false
 }
 
 func (t *TreeConverter) headerBlock(n *html.Node, blockChar string, prefix bool) ([]string, error) {


### PR DESCRIPTION
An image wrapped in a link becomes just the link if it is missing alt text