### PR TITLE
Fix edge case in Wrap

### DIFF
--- a/wrap.go
+++ b/wrap.go
@@ -30,17 +30,11 @@ func WordWrap(txt string, lineLength int) string {
 			final = append(final, line[startIndex:startIndex+newIndex])
 			startIndex += newIndex
 
-			if startIndex >= len(line) {
-				break
-			}
-
 			// clear any extra space
-			for ; line[startIndex] == ' '; startIndex++ {
+			for ; startIndex < len(line) && line[startIndex] == ' '; startIndex++ {
 			}
 		}
-		if startIndex <= len(line) {
-			final = append(final, line[startIndex:])
-		}
+		final = append(final, line[startIndex:])
 	}
 
 	return strings.Join(final, "\n")

--- a/wrap.go
+++ b/wrap.go
@@ -30,11 +30,17 @@ func WordWrap(txt string, lineLength int) string {
 			final = append(final, line[startIndex:startIndex+newIndex])
 			startIndex += newIndex
 
+			if startIndex >= len(line) {
+				break
+			}
+
 			// clear any extra space
 			for ; line[startIndex] == ' '; startIndex++ {
 			}
 		}
-		final = append(final, line[startIndex:])
+		if startIndex <= len(line) {
+			final = append(final, line[startIndex:])
+		}
 	}
 
 	return strings.Join(final, "\n")

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -18,3 +18,10 @@ func TestWrappingInvalidLength(t *testing.T) {
 	wrapped := textplain.WordWrap(body, -1)
 	assert.Equal(t, body, wrapped)
 }
+
+func TestWrappingEdgeCase(t *testing.T) {
+	body := "1 23 45\n67\n1234567890 1   "
+
+	wrapped := textplain.WordWrap(body, 13)
+	assert.Equal(t, "1 23 45\n67\n1234567890 1 \n", wrapped)
+}


### PR DESCRIPTION
startIdx can be equal to `len(line)` - this breaks properly in that case