### PR TITLE
DefaultConverter & Fix bounds error on long trailing whitespace

### DIFF
--- a/textplain.go
+++ b/textplain.go
@@ -14,7 +14,7 @@ var (
 	ErrBodyNotFound = errors.New("could not find a `body` element in your html document")
 )
 
-var defaultConverter = NewRegexpConverter()
+var defaultConverter = NewTreeConverter()
 
 // Convert is a convenience method so the library can be used without initializing a converter
 // because this library relies heavily on regexp objects, it may act as a bottlneck to concurrency

--- a/wrap.go
+++ b/wrap.go
@@ -21,6 +21,8 @@ func WordWrap(txt string, lineLength int) string {
 			endIndex += lineLength
 			if endIndex >= len(line) {
 				endIndex = len(line) - 1
+			} else if endIndex < startIndex {
+				endIndex = startIndex
 			}
 
 			newIndex := strings.LastIndex(line[startIndex:endIndex+1], " ")

--- a/wrap.go
+++ b/wrap.go
@@ -17,11 +17,12 @@ func WordWrap(txt string, lineLength int) string {
 	var final []string
 	for _, line := range strings.Split(txt, "\n") {
 		var startIndex, endIndex int
-		for (len(line) - endIndex) > lineLength {
+		for (len(line)-endIndex) > lineLength && startIndex < len(line) {
 			endIndex += lineLength
 			if endIndex >= len(line) {
 				endIndex = len(line) - 1
 			}
+
 			newIndex := strings.LastIndex(line[startIndex:endIndex+1], " ")
 			if newIndex <= 0 {
 				continue

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -1,6 +1,7 @@
 package textplain_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/mailproto/textplain"
@@ -19,9 +20,12 @@ func TestWrappingInvalidLength(t *testing.T) {
 	assert.Equal(t, body, wrapped)
 }
 
-func TestWrappingEdgeCase(t *testing.T) {
+func TestWrappingEdgeCases(t *testing.T) {
 	body := "1 23 45\n67\n1234567890 1   "
 
 	wrapped := textplain.WordWrap(body, 13)
 	assert.Equal(t, "1 23 45\n67\n1234567890 1 \n", wrapped)
+
+	wrapped = textplain.WordWrap("1234567890"+strings.Repeat(" ", 20), 10)
+	assert.Equal(t, "1234567890\n", wrapped)
 }

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -20,7 +20,7 @@ func TestWrappingInvalidLength(t *testing.T) {
 	assert.Equal(t, body, wrapped)
 }
 
-func TestWrappingEdgeCases(t *testing.T) {
+func TestWrappingTrailingWhitespace(t *testing.T) {
 	body := "1 23 45\n67\n1234567890 1   "
 
 	wrapped := textplain.WordWrap(body, 13)


### PR DESCRIPTION
Even longer trailing whitespace results in a different out-of-bounds issue due to slice bounds issues.

The wrapper could do with a rewrite, but in the meantime, this ensures we don't ever try and grab an invalid slice